### PR TITLE
Sets errorContext error when availability check fails

### DIFF
--- a/TravelerKitUI/ViewControllers/BookableDetailsViewController.swift
+++ b/TravelerKitUI/ViewControllers/BookableDetailsViewController.swift
@@ -190,6 +190,8 @@ extension BookableDetailsViewController: AvailabilityCheckDelegate {
     func availabilityCheckDidFailWith(_ error: Error) {
         tableView.isUserInteractionEnabled = true
 
+        errorContext?.error = BookingError.noDate
+
         let alert = UIAlertController(title: "Error", message: "Sorry, something went wrong!", preferredStyle: .alert)
         let action = UIAlertAction(title: "OK", style: .cancel, handler: nil)
         alert.addAction(action)


### PR DESCRIPTION
**Description**
Sets errorContext to be .noDate to prevent the crash since we don't have any error handling for no network connectivity yet. Can be set to a more descriptive error when we do. 

**Issues that should be CLOSED by merge of this PR:**
* Fixes #128

**Related issues that should be LINKED to this PR:**
* Connects #